### PR TITLE
Move jest-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-codebox",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A set of ESLint rules we use at Codebox",
   "main": "./lib/index.js",
   "scripts": {
@@ -47,6 +47,7 @@
     "eslint-plugin-prettier": "^2.4.0",
     "eslint-plugin-react": "^7.5.1",
     "jest": "^22.0.4",
+    "jest-cli": "^22.0.4",
     "prettier": "^1.9.2"
   },
   "peerDependencies": {
@@ -55,7 +56,6 @@
   "dependencies": {
     "builtin-modules": "^2.0.0",
     "eslint-module-utils": "^2.1.1",
-    "jest-cli": "^22.0.4",
     "lodash": "^4.17.4"
   }
 }


### PR DESCRIPTION
`jest-cli` does not need to be a production dependency, moved to `devDependencies`

Resolves #7 