### PR TITLE
Fix: ignoreCase = false works as intended

### DIFF
--- a/__test__/rules/sort-named-imports.spec.js
+++ b/__test__/rules/sort-named-imports.spec.js
@@ -18,6 +18,23 @@ ruleTester.run('codebox/sort-named-imports', sortNamedImportsRule, {
       `,
       options: [{ ignoreCase: true }],
     },
+    {
+      code: `
+        import { a, B, c } from 'fs'
+      `,
+      options: [{ ignoreCase: true }],
+    },
+    {
+      code: `
+        import { a, B, c } from 'fs'
+      `,
+    },
+    {
+      code: `
+        import { B, a, c } from 'fs'
+      `,
+      options: [{ ignoreCase: false }],
+    },
   ],
   invalid: [
     {
@@ -28,6 +45,16 @@ ruleTester.run('codebox/sort-named-imports', sortNamedImportsRule, {
       options: [{ ignoreCase: true }],
       output: `
         import { a, b, c } from 'fs'
+      `,
+    },
+    {
+      code: `
+        import { a, B, c } from 'fs'
+      `,
+      errors: [{ message: `Member 'B' of the import declaration should be sorted alphabetically` }],
+      options: [{ ignoreCase: false }],
+      output: `
+        import { B, a, c } from 'fs'
       `,
     },
   ],

--- a/src/rules/sort-named-imports.js
+++ b/src/rules/sort-named-imports.js
@@ -26,7 +26,7 @@ module.exports = {
   create(context) {
     const sourceCode = context.getSourceCode()
     const config = context.options[0] || {}
-    const ignoreCase = config.ignoreCase || true
+    const ignoreCase = config.ignoreCase !== undefined ? config.ignoreCase : true;
     return {
       ImportDeclaration(node) {
         const importSpecifiers = node.specifiers.filter(


### PR DESCRIPTION
ignoreCase was treated as true, no matter what was set in the config.

This PR sets ignoreCase only to true, if it was undefined in the config